### PR TITLE
[IN-490] Move MaxMessageSize directive to the top

### DIFF
--- a/rsyslog/templates/rsyslog.conf.jinja
+++ b/rsyslog/templates/rsyslog.conf.jinja
@@ -126,4 +126,4 @@ $IMJournalStateFile imjournal.state
 # $IMJournalIgnorePreviousMessages on
 {%- endif %}
 
-$MaxMessageSize 16k
+$MaxMessageSize 64k

--- a/rsyslog/templates/rsyslog.conf.jinja
+++ b/rsyslog/templates/rsyslog.conf.jinja
@@ -3,6 +3,7 @@
 #                       For more information see
 #                       /usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
 
+$MaxMessageSize 32k
 
 #################
 #### MODULES ####
@@ -126,4 +127,3 @@ $IMJournalStateFile imjournal.state
 # $IMJournalIgnorePreviousMessages on
 {%- endif %}
 
-$MaxMessageSize 64k


### PR DESCRIPTION
In rsyslog documentation

"$MaxMessageSize <size_nbr>, default 8k - allows to specify maximum supported message size (both for sending and receiving). The default should be sufficient for almost all cases. Do not set this below 1k, as it would cause interoperability problems with other syslog implementations.

Important: In order for this directive to work correctly, it must be placed right at the top of rsyslog.conf (before any input is defined)."

We were specifying "MaxMessageSize" at the bottom, after all config files defining inputs were loaded