### PR TITLE
create symlink to rsyslog service file

### DIFF
--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -68,6 +68,7 @@ rsyslog_service:
     - require:
       - pkg: {{ rsyslog.package }}
       - rsyslog_mmjsonparse
+      - syslog_symlink
     - watch:
       - file: {{ rsyslog.config }}
       - file: /etc/rsyslog.d/*

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -55,6 +55,12 @@ service_file:
     - name: /lib/systemd/system/rsyslog.service
     - source: salt:///rsyslog/service_files/rsyslog.service
 
+syslog_symlink:
+  file.symlink:
+    - name: /etc/systemd/system/syslog.service
+    - target: /lib/systemd/system/rsyslog.service
+    - force: True
+
 rsyslog_service:
   service.running:
     - enable: True


### PR DESCRIPTION
We see following error often when people run salt update on the hlcs. This happens because the syslog service doesn't have a symlink to the rsyslog service file. 

```
Feb 17 22:18:58 osr-hq-gp7-1 systemd[1]: Starting System Logging Service...
-- Subject: Unit rsyslog.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit rsyslog.service has begun starting up.
Feb 17 22:18:58 osr-hq-gp7-1 systemd[1]: syslog.socket: Socket service syslog.service not loaded, refusing.
Feb 17 22:18:58 osr-hq-gp7-1 systemd[1]: Failed to listen on Syslog Socket.
-- Subject: Unit syslog.socket has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit syslog.socket has failed.
-- 
-- The result is failed.
Feb 17 22:18:58 osr-hq-gp7-1 systemd[1]: Dependency failed for System Logging Service.
-- Subject: Unit rsyslog.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit rsyslog.service has failed.
-- 
-- The result is dependency.
Feb 17 22:18:58 osr-hq-gp7-1 systemd[1]: rsyslog.service: Job rsyslog.service/start failed with result 'dependency'.
Feb 17 22:18:59 osr-hq-gp7-1 sudo[8040]: pam_unix(sudo:session): session closed for user root
Feb 17 22:19:01 osr-hq-gp7-1 collectd[3151]: parse_value: Failed to parse string as gauge: "[N/A]".
Feb 17 22:19:01 osr-hq-gp7-1 collectd[3151]: -1 Parsing the values string failed.
```